### PR TITLE
Fix errors on single plane clips

### DIFF
--- a/placebo.py
+++ b/placebo.py
@@ -40,7 +40,8 @@ def deband(clip: vs.VideoNode, radius: float = 16.0,
             It's recommended to either scale this value down or disable it entirely for HDR.
             Defaults to 6.0, which is very mild.
 
-        chroma (bool, optional): Process chroma planes or not. Defaults to True if the input clip has chroma planes.
+        chroma (bool, optional): Process chroma planes or not.
+            Defaults to True if the input clip has chroma planes.
 
     Returns:
         vs.VideoNode: Debanded clip.

--- a/placebo.py
+++ b/placebo.py
@@ -40,12 +40,12 @@ def deband(clip: vs.VideoNode, radius: float = 16.0,
             It's recommended to either scale this value down or disable it entirely for HDR.
             Defaults to 6.0, which is very mild.
 
-        chroma (bool, optional): Process chroma planes or not. Defaults to True.
+        chroma (bool, optional): Process chroma planes or not. Defaults to True if the input clip has chroma planes.
 
     Returns:
         vs.VideoNode: Debanded clip.
     """
-    if chroma:
+    if chroma and clip.format.num_planes > 1:
         if isinstance(threshold, (float, int)):
             threshold = [cast(float, threshold)]
 


### PR DESCRIPTION
`deband` throws errors when a clip with only one plane is passed in and `chroma` isn't explicitly set to false.
Example code for the behavior:
```py
y,u,v = vsutil.split(clip)
debandy = placebo.deband(clip) # Errors here
deband = vsutil.join(debandy,u,v)
deband.set_output()

>>> IndexError: list index is out of range on placebo.py line 73
```
This adds a check if the clip has more than one plane when processing with `chroma=True`, effectively making single-plane clips behave as if setting `chroma=False`