### PR TITLE
Replace `lvsfunc.kernel` with `vskernels`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 VapourSynth>=56
 vsutil>=0.5.0
+vs-kernels>=1.0.0
 vsmask>=0.3.0
 lvsfunc>=0.3.7
 numpy>=1.21.1

--- a/vardefunc/aa.py
+++ b/vardefunc/aa.py
@@ -15,7 +15,7 @@ from functools import partial
 from typing import Any, Callable, Dict, Optional
 
 import vapoursynth as vs
-from lvsfunc.kernels import Catrom, Kernel
+from vskernels import Catrom, Kernel
 from vsutil import get_w
 
 core = vs.core

--- a/vardefunc/mask.py
+++ b/vardefunc/mask.py
@@ -19,8 +19,7 @@ from vsmask.edge import Kirsch as KirschVsM
 from vsmask.edge import MinMax as MinMaxVsM
 from vsmask.util import XxpandMode
 from vsmask.util import expand as expand_func
-from vsutil import (depth, get_depth, get_w, get_y, insert_clip, iterate, join,
-                    scale_value, split)
+from vsutil import depth, get_depth, get_w, get_y, insert_clip, iterate, join, scale_value, split
 
 from .types import Zimg, format_not_none
 from .util import get_sample_type, mae_expr, max_expr, pick_px_op

--- a/vardefunc/mask.py
+++ b/vardefunc/mask.py
@@ -10,8 +10,8 @@ import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-import lvsfunc
 import vapoursynth as vs
+import vskernels
 from vsmask.edge import EdgeDetect as EdgeDetectVsM
 from vsmask.edge import ExLaplacian4 as ExLaplacian4VsM
 from vsmask.edge import FDOGTCanny as FDOGTCannyVsM
@@ -19,7 +19,8 @@ from vsmask.edge import Kirsch as KirschVsM
 from vsmask.edge import MinMax as MinMaxVsM
 from vsmask.util import XxpandMode
 from vsmask.util import expand as expand_func
-from vsutil import depth, get_depth, get_w, get_y, insert_clip, iterate, join, scale_value, split
+from vsutil import (depth, get_depth, get_w, get_y, insert_clip, iterate, join,
+                    scale_value, split)
 
 from .types import Zimg, format_not_none
 from .util import get_sample_type, mae_expr, max_expr, pick_px_op
@@ -50,7 +51,7 @@ class Difference():
     """Collection of function based on differences between prediction and observation"""
 
     def rescale(self, clip: vs.VideoNode, height: int = 720,
-                kernel: lvsfunc.kernels.Kernel = lvsfunc.kernels.Catrom(),
+                kernel: vskernels.Kernel = vskernels.Catrom(),
                 thr: Union[int, float] = 55, expand: int = 2) -> vs.VideoNode:
         """Makes a mask based on rescaled difference.
            Modified version of Atomchtools.
@@ -64,8 +65,8 @@ class Difference():
             height (int, optional):
                 Height to descale to. Defaults to 720.
 
-            kernel (lvsfunc.kernels.Kernel, optional):
-                Kernel used to descale. Defaults to lvsfunc.kernels.Bicubic(b=0, c=0.5).
+            kernel (vskernels.Kernel, optional):
+                Kernel used to descale. Defaults to vskernels.Bicubic(b=0, c=0.5).
 
             thr (Union[int, float], optional):
                 Binarization threshold. Defaults to 55.
@@ -228,7 +229,7 @@ def diff_creditless_mask(src_clip: vs.VideoNode, credit_clip: vs.VideoNode, nc_c
 
 
 def diff_rescale_mask(clip: vs.VideoNode, height: int = 720,
-                      kernel: lvsfunc.kernels.Kernel = lvsfunc.kernels.Catrom(),
+                      kernel: vskernels.Kernel = vskernels.Catrom(),
                       thr: Union[int, float] = 55, expand: int = 2) -> vs.VideoNode:
     """Legacy function of Difference().rescale"""
     return Difference().rescale(clip, height, kernel, thr, expand)

--- a/vardefunc/scale.py
+++ b/vardefunc/scale.py
@@ -8,7 +8,7 @@ __all__ = [
 from functools import partial
 from typing import Any, Callable, Dict, List, Literal, Optional, Union, overload
 
-import lvsfunc
+import vskernels
 import vapoursynth as vs
 from vsutil import depth, get_depth, get_w, get_y, join, split
 
@@ -19,7 +19,7 @@ core = vs.core
 
 
 def nnedi3cl_double(clip: vs.VideoNode,
-                    scaler: lvsfunc.kernels.Kernel = lvsfunc.kernels.Catrom(),
+                    scaler: vskernels.Kernel = vskernels.Catrom(),
                     correct_shift: bool = True, use_znedi: bool = False, **nnedi3_args: Any) -> vs.VideoNode:
     """Double the clip using nnedi3 for even frames and nnedi3cl for odd frames
        Intended to speed up encoding speed without hogging the GPU either.
@@ -27,8 +27,8 @@ def nnedi3cl_double(clip: vs.VideoNode,
     Args:
         clip (vs.VideoNode): Source clip.
 
-        scaler (lvsfunc.kernels.Kernel, optional):
-            Resizer used to correct the shift. Defaults to lvsfunc.kernels.Bicubic().
+        scaler (vskernels.Kernel, optional):
+            Resizer used to correct the shift. Defaults to vskernels.Bicubic().
 
         correct_shift (bool, optional):
             Corrects the shift introduced by nnedi3 or not. Defaults to True.
@@ -59,15 +59,15 @@ def nnedi3cl_double(clip: vs.VideoNode,
     return scaler.scale(clip, clip.width, clip.height, shift=(.5, .5)) if correct_shift else clip
 
 
-def nnedi3_upscale(clip: vs.VideoNode, scaler: lvsfunc.kernels.Kernel = lvsfunc.kernels.Catrom(),
+def nnedi3_upscale(clip: vs.VideoNode, scaler: vskernels.Kernel = vskernels.Catrom(),
                    correct_shift: bool = True, use_znedi: bool = False, **nnedi3_args: Any) -> vs.VideoNode:
     """Classic based nnedi3 upscale.
 
     Args:
         clip (vs.VideoNode): Source clip.
 
-        scaler (lvsfunc.kernels.Kernel, optional):
-            Resizer used to correct the shift. Defaults to lvsfunc.kernels.Bicubic().
+        scaler (vskernels.Kernel, optional):
+            Resizer used to correct the shift. Defaults to vskernels.Bicubic().
 
         correct_shift (bool, optional):
             Corrects the shift introduced by nnedi3 or not. Defaults to True.
@@ -91,7 +91,7 @@ def nnedi3_upscale(clip: vs.VideoNode, scaler: lvsfunc.kernels.Kernel = lvsfunc.
     return scaler.scale(clip, clip.width, clip.height, shift=(.5, .5)) if correct_shift else clip
 
 
-def eedi3_upscale(clip: vs.VideoNode, scaler: lvsfunc.kernels.Kernel = lvsfunc.kernels.Catrom(),
+def eedi3_upscale(clip: vs.VideoNode, scaler: vskernels.Kernel = vskernels.Catrom(),
                   correct_shift: bool = True,
                   nnedi3_args: Optional[Dict[str, Any]] = None, eedi3_args: Optional[Dict[str, Any]] = None) -> vs.VideoNode:
     """Upscale function using the power of eedi3 and nnedi3.
@@ -101,8 +101,8 @@ def eedi3_upscale(clip: vs.VideoNode, scaler: lvsfunc.kernels.Kernel = lvsfunc.k
     Args:
         clip (vs.VideoNode): Source clip.
 
-        scaler (lvsfunc.kernels.Kernel, optional):
-            Resizer used to correct the shift. Defaults to lvsfunc.kernels.Bicubic().
+        scaler (vskernels.Kernel, optional):
+            Resizer used to correct the shift. Defaults to vskernels.Bicubic().
 
         correct_shift (bool, optional):
             Corrects the shift introduced by nnedi3 or not. Defaults to True.
@@ -305,7 +305,7 @@ def placebo_shader(clip: vs.VideoNode, width: int, height: int, shader_file: str
 def to_444(clip: vs.VideoNode,
            width: Optional[int], height: Optional[int],
            join_planes: Literal[True], znedi: bool = True,
-           scaler: lvsfunc.kernels.Kernel = lvsfunc.kernels.Catrom()
+           scaler: vskernels.Kernel = vskernels.Catrom()
            ) -> vs.VideoNode:
     ...
 
@@ -314,7 +314,7 @@ def to_444(clip: vs.VideoNode,
 def to_444(clip: vs.VideoNode,
            width: Optional[int], height: Optional[int],
            join_planes: Literal[False], znedi: bool = True,
-           scaler: lvsfunc.kernels.Kernel = lvsfunc.kernels.Catrom()
+           scaler: vskernels.Kernel = vskernels.Catrom()
            ) -> List[vs.VideoNode]:
     ...
 
@@ -323,7 +323,7 @@ def to_444(clip: vs.VideoNode,
 def to_444(clip: vs.VideoNode,
            width: Optional[int], height: Optional[int],
            join_planes: bool, znedi: bool = True,
-           scaler: lvsfunc.kernels.Kernel = lvsfunc.kernels.Catrom()
+           scaler: vskernels.Kernel = vskernels.Catrom()
            ) -> Union[vs.VideoNode, List[vs.VideoNode]]:
     ...
 
@@ -331,7 +331,7 @@ def to_444(clip: vs.VideoNode,
 def to_444(clip: vs.VideoNode,
            width: Optional[int], height: Optional[int],
            join_planes: bool, znedi: bool = True,
-           scaler: lvsfunc.kernels.Kernel = lvsfunc.kernels.Catrom()
+           scaler: vskernels.Kernel = vskernels.Catrom()
            ) -> Union[vs.VideoNode, List[vs.VideoNode]]:
     """Zastin’s nnedi3 chroma upscaler.
        Modified by Vardë.
@@ -352,8 +352,8 @@ def to_444(clip: vs.VideoNode,
 
         znedi (bool, optional): Defaults to True.
 
-        scaler (lvsfunc.kernels.Kernel, optional):
-            Resizer used to correct the shift. Defaults to lvsfunc.kernels.Bicubic().
+        scaler (vskernels.Kernel, optional):
+            Resizer used to correct the shift. Defaults to vskernels.Bicubic().
 
     Returns:
         Union[vs.VideoNode, List[vs.VideoNode]]: 444'd clip or chroma planes.


### PR DESCRIPTION
`kernels` has split off from `lvsfunc` and is now its own package.
https://vskernels.encode.moe/en/latest/