### PR TITLE
fix normalise_ranges error when using FileInfo2

### DIFF
--- a/vardefunc/util.py
+++ b/vardefunc/util.py
@@ -323,8 +323,8 @@ def normalise_ranges(clip: vs.VideoNode | vs.AudioNode, ranges: Range | List[Ran
             start = r
             end = r + 1
         if isinstance(clip, vs.AudioNode) and ref_fps is not None:
-            start = f2s(start, ref_fps, clip.sample_rate)
-            end = f2s(end, ref_fps, clip.sample_rate)
+            start = start if start == 0 else f2s(start, ref_fps, clip.sample_rate)
+            end = end if end == num_frames else f2s(end, ref_fps, clip.sample_rate)
         if start < 0:
             start += num_frames
         if end <= 0:


### PR DESCRIPTION
```
normalise_ranges: "(None, None)" out of range
C:\Python310\lib\site-packages\vardefunc-0.7.1-py3.10.egg\vardefunc\util.py:338: UserWarning: normalise_ranges: (None, None) out of range
  warnings.warn(f'normalise_ranges: {r} out of range')
```

failed specifically for when `(None, None)` is passed because it is being given the total # samples as `num_frames` when given a `vs.AudioNode`

sample input when given `vs.AudioNode`:
```
[(None, None)]
num_frames: 63595507
start: 0
end: 63595507
```
current code after going thru the start/end adjustment for `vs.AudioNode` input:
```
[(None, None)]
num_frames: 63595507
start: 0
end: 116973600857 << incorrect sample value
```
fixed code after adjustments:
```
[(None, None)]
num_frames: 63595507
start: 0
end: 63595507
```
fixed code example with a a real trim:
```
[(None, 50)]
num_frames: 63595507
start: 0
end: 50
```